### PR TITLE
refactor: of the amountOrCallOrId variable, where the call is removed because is not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Easily create and return the Asset type to use in your Swap by calling this func
 ```solidity
 struct Asset {
     address addr;
-    uint256 amountOrCallOrId;
+    uint256 amountOrId;
 }
 ```
 

--- a/contracts/SwapFactory.sol
+++ b/contracts/SwapFactory.sol
@@ -8,7 +8,7 @@ error InvalidAddress(address caller);
 error InvalidAmount(uint256 amount);
 error InvalidAssetsLength();
 error InvalidExpiryDate(uint256 timestamp);
-error InvalidMismatchingLengths(uint256 addr, uint256 amountOrCallOrId);
+error InvalidMismatchingLengths(uint256 addr, uint256 amountOrId);
 
 /**
  *  ________   ___        ________   ________   ___  __     ________  ___  ___   ___
@@ -27,9 +27,9 @@ error InvalidMismatchingLengths(uint256 addr, uint256 amountOrCallOrId);
 abstract contract SwapFactory is ISwapFactory, ISwap {
     function makeAsset(
         address addr,
-        uint256 amountOrCallOrId
+        uint256 amountOrId
     ) public pure returns (Asset memory) {
-        return Asset(addr, amountOrCallOrId);
+        return Asset(addr, amountOrId);
     }
 
     function makeSwap(
@@ -59,19 +59,16 @@ abstract contract SwapFactory is ISwapFactory, ISwap {
         address allowed,
         uint256 expiry,
         address[] memory addrs,
-        uint256[] memory amountOrCallOrId,
+        uint256[] memory amountOrId,
         uint256 bidFlipAsk
     ) public pure returns (Swap memory) {
-        if (addrs.length != amountOrCallOrId.length) {
-            revert InvalidMismatchingLengths(
-                addrs.length,
-                amountOrCallOrId.length
-            );
+        if (addrs.length != amountOrId.length) {
+            revert InvalidMismatchingLengths(addrs.length, amountOrId.length);
         }
 
         Asset[] memory biding = new Asset[](bidFlipAsk);
         for (uint256 i = 0; i < bidFlipAsk; ) {
-            biding[i] = makeAsset(addrs[i], amountOrCallOrId[i]);
+            biding[i] = makeAsset(addrs[i], amountOrId[i]);
             unchecked {
                 i++;
             }
@@ -79,7 +76,7 @@ abstract contract SwapFactory is ISwapFactory, ISwap {
 
         Asset[] memory asking = new Asset[](addrs.length - bidFlipAsk);
         for (uint256 i = bidFlipAsk; i < addrs.length; ) {
-            asking[i - bidFlipAsk] = makeAsset(addrs[i], amountOrCallOrId[i]);
+            asking[i - bidFlipAsk] = makeAsset(addrs[i], amountOrId[i]);
             unchecked {
                 i++;
             }

--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -76,7 +76,7 @@ contract Swaplace is SwapFactory, DataPalace, ISwaplace, IERC165 {
             ITransfer(assets[i].addr).transferFrom(
                 msg.sender,
                 swap.owner,
-                assets[i].amountOrCallOrId
+                assets[i].amountOrId
             );
             unchecked {
                 i++;
@@ -89,7 +89,7 @@ contract Swaplace is SwapFactory, DataPalace, ISwaplace, IERC165 {
             ITransfer(assets[i].addr).transferFrom(
                 swap.owner,
                 msg.sender,
-                assets[i].amountOrCallOrId
+                assets[i].amountOrId
             );
             unchecked {
                 i++;

--- a/contracts/interfaces/ISwap.sol
+++ b/contracts/interfaces/ISwap.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 interface ISwap {
     struct Asset {
         address addr;
-        uint256 amountOrCallOrId;
+        uint256 amountOrId;
     }
 
     struct Swap {

--- a/contracts/interfaces/ISwapFactory.sol
+++ b/contracts/interfaces/ISwapFactory.sol
@@ -6,7 +6,7 @@ import {ISwap} from "./ISwap.sol";
 interface ISwapFactory {
     function makeAsset(
         address addr,
-        uint256 amountOrCallOrId
+        uint256 amountOrId
     ) external pure returns (ISwap.Asset memory);
 
     function makeSwap(
@@ -22,7 +22,7 @@ interface ISwapFactory {
         address allowed,
         uint256 expiry,
         address[] memory addrs,
-        uint256[] memory amountOrCallOrId,
+        uint256[] memory amountOrId,
         uint256 indexFlipToAsking
     ) external pure returns (ISwap.Swap memory);
 }

--- a/contracts/interfaces/ITransfer.sol
+++ b/contracts/interfaces/ITransfer.sol
@@ -5,6 +5,6 @@ interface ITransfer {
     function transferFrom(
         address from,
         address to,
-        uint256 amountOrCallOrId
+        uint256 amountOrId
     ) external;
 }


### PR DESCRIPTION
Refactored the name of the variable amountOrCallOrId into just amountOrId

closes #16 