### PR TITLE
refactor: compose swap on the contract side is not necessary as it can be delegate to the implementer

### DIFF
--- a/contracts/SwapFactory.sol
+++ b/contracts/SwapFactory.sol
@@ -28,7 +28,7 @@ abstract contract SwapFactory is ISwapFactory, ISwap {
     function makeAsset(
         address addr,
         uint256 amountOrId
-    ) public pure returns (Asset memory) {
+    ) public pure virtual returns (Asset memory) {
         return Asset(addr, amountOrId);
     }
 
@@ -38,7 +38,7 @@ abstract contract SwapFactory is ISwapFactory, ISwap {
         uint256 expiry,
         Asset[] memory biding,
         Asset[] memory asking
-    ) public view returns (Swap memory) {
+    ) public view virtual returns (Swap memory) {
         if (owner == address(0)) {
             revert InvalidAddress(address(0));
         }
@@ -52,36 +52,5 @@ abstract contract SwapFactory is ISwapFactory, ISwap {
         }
 
         return Swap(owner, allowed, expiry, biding, asking);
-    }
-
-    function composeSwap(
-        address owner,
-        address allowed,
-        uint256 expiry,
-        address[] memory addrs,
-        uint256[] memory amountOrId,
-        uint256 bidFlipAsk
-    ) public view returns (Swap memory) {
-        if (addrs.length != amountOrId.length) {
-            revert InvalidMismatchingLengths(addrs.length, amountOrId.length);
-        }
-
-        Asset[] memory biding = new Asset[](bidFlipAsk);
-        for (uint256 i = 0; i < bidFlipAsk; ) {
-            biding[i] = makeAsset(addrs[i], amountOrId[i]);
-            unchecked {
-                i++;
-            }
-        }
-
-        Asset[] memory asking = new Asset[](addrs.length - bidFlipAsk);
-        for (uint256 i = bidFlipAsk; i < addrs.length; ) {
-            asking[i - bidFlipAsk] = makeAsset(addrs[i], amountOrId[i]);
-            unchecked {
-                i++;
-            }
-        }
-
-        return makeSwap(owner, allowed, expiry, biding, asking);
     }
 }

--- a/contracts/interfaces/ISwapFactory.sol
+++ b/contracts/interfaces/ISwapFactory.sol
@@ -16,13 +16,4 @@ interface ISwapFactory {
         ISwap.Asset[] memory assets,
         ISwap.Asset[] memory asking
     ) external view returns (ISwap.Swap memory);
-
-    function composeSwap(
-        address owner,
-        address allowed,
-        uint256 expiry,
-        address[] memory addrs,
-        uint256[] memory amountOrId,
-        uint256 indexFlipToAsking
-    ) external view returns (ISwap.Swap memory);
 }

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -2,6 +2,13 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, network } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+	Swap,
+	Asset,
+	makeAsset,
+	makeSwap,
+	composeSwap,
+} from "./utils/SwapFactory";
 
 describe("Swaplace", async function () {
 	let Swaplace: Contract;
@@ -11,8 +18,8 @@ describe("Swaplace", async function () {
 	let owner: SignerWithAddress;
 	let acceptee: SignerWithAddress;
 
-	const day = 86400;
 	const zeroAddress = ethers.constants.AddressZero;
+	const day = 86400;
 
 	before(async () => {
 		const [signer, accountOne] = await ethers.getSigners();
@@ -54,16 +61,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, 1];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [1];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap
@@ -71,7 +82,7 @@ describe("Swaplace", async function () {
 
 		// Return the first swap and expect timestamp to be the same
 		const swapResult = await Swaplace.getSwap(1);
-		expect(swapResult[2]).to.be.equal(swap[2]);
+		expect(swapResult.expiry).to.be.equal(swap.expiry);
 
 		// Create a second swap
 		expect(await Swaplace.createSwap(swap)).to.be.ok;
@@ -98,16 +109,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, 1];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [1];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap
@@ -124,16 +139,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, 1];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [1];
+
+		const swap = await composeSwap(
 			acceptee.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap
@@ -141,10 +160,6 @@ describe("Swaplace", async function () {
 
 		// Get last swap id
 		const lastSwap = await Swaplace.swapId();
-
-		// Return the first swap and expect timestamp to be greater
-		const swapResult = await Swaplace.getSwap(Number(lastSwap));
-		expect(swapResult[2]).to.be.equal(swap[2]);
 
 		// Try to cancel the swap as owner
 		await expect(
@@ -156,16 +171,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, 1];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [1];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap
@@ -187,16 +206,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, 1];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [1];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap
@@ -226,16 +249,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, tokenId];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [tokenId];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap by owner
@@ -275,16 +302,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [10000, tokenId];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [tokenId];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap by owner
@@ -315,16 +346,20 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC721.address];
-		const assetsAmountsOrId = [1000, tokenId];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [tokenId];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap by owner
@@ -348,22 +383,26 @@ describe("Swaplace", async function () {
 	it("Should be able to accept a swap with only { ERC20 }", async function () {
 		// Mint tokens
 		await MockERC20.mintTo(owner.address, 1000);
-		await MockERC20.mintTo(acceptee.address, 10000);
+		await MockERC20.mintTo(acceptee.address, 2000);
 
 		// Build the Swap
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC20.address, MockERC20.address];
-		const assetsAmountsOrId = [1000, 10000];
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC20.address];
+		const askingAmountOrId = [2000];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap by owner
@@ -400,21 +439,21 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [MockERC721.address, MockERC721.address];
-		const assetsAmountsOrId = [tokenId - 1, tokenId];
+		const bidingAddr = [MockERC721.address];
+		const bidingAmountOrId = [tokenId - 1];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC721.address];
+		const askingAmountOrId = [tokenId];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
-
-		// estimate gas
-		const gas = await Swaplace.estimateGas.createSwap(swap);
-		console.log(gas);
 
 		// Create the first swap by owner
 		expect(await Swaplace.createSwap(swap)).to.be.ok;
@@ -430,12 +469,6 @@ describe("Swaplace", async function () {
 
 		// Get last swap id
 		const lastSwap = await Swaplace.swapId();
-
-		// estimate gas
-		const gas2 = await Swaplace.connect(acceptee).estimateGas.acceptSwap(
-			Number(lastSwap)
-		);
-		console.log(gas2);
 
 		// Accept swap as acceptee
 		expect(await Swaplace.connect(acceptee).acceptSwap(Number(lastSwap))).to.be
@@ -462,21 +495,24 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [
-			MockERC20.address,
+		const bidingAddr = [MockERC20.address];
+		const bidingAmountOrId = [1000];
+
+		const askingAddr = [
 			MockERC721.address,
 			MockERC721.address,
 			MockERC721.address,
 		];
-		const assetsAmountsOrId = [1000, tokenId - 2, tokenId - 1, tokenId];
+		const askingAmountOrId = [tokenId - 2, tokenId - 1, tokenId];
 
-		const swap = await Swaplace.composeSwap(
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			1
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
 
 		// Create the first swap by owner
@@ -524,26 +560,21 @@ describe("Swaplace", async function () {
 		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
 		const expiry = timestamp + day * 2;
 
-		const assetsContractAddrs = [
-			MockERC20.address,
-			MockERC721.address,
-			MockERC20.address,
-			MockERC721.address,
-		];
-		const assetsAmountsOrId = [1000, tokenId - 1, 1000, tokenId];
+		const bidingAddr = [MockERC20.address, MockERC721.address];
+		const bidingAmountOrId = [1000, tokenId - 1];
 
-		const swap = await Swaplace.composeSwap(
+		const askingAddr = [MockERC20.address, MockERC721.address];
+		const askingAmountOrId = [1000, tokenId];
+
+		const swap = await composeSwap(
 			owner.address,
 			zeroAddress,
 			expiry,
-			assetsContractAddrs,
-			assetsAmountsOrId,
-			2
+			bidingAddr,
+			bidingAmountOrId,
+			askingAddr,
+			askingAmountOrId
 		);
-
-		// estimate gas
-		const gas = await Swaplace.estimateGas.createSwap(swap);
-		console.log(gas);
 
 		// Create the first swap by owner
 		expect(await Swaplace.createSwap(swap)).to.be.ok;
@@ -561,12 +592,6 @@ describe("Swaplace", async function () {
 		const balanceBeforeOwner = await MockERC20.balanceOf(owner.address);
 		const balanceBefore = await MockERC20.balanceOf(acceptee.address);
 
-		// estimate gas
-		const gas2 = await Swaplace.connect(acceptee).estimateGas.acceptSwap(
-			Number(lastSwap)
-		);
-
-		console.log(gas2);
 		// accept swap as acceptee
 		expect(await Swaplace.connect(acceptee).acceptSwap(Number(lastSwap))).to.be
 			.ok;

--- a/test/utils/SwapFactory.ts
+++ b/test/utils/SwapFactory.ts
@@ -1,0 +1,160 @@
+import { ethers } from "hardhat";
+import { isValidAddr } from "./utils";
+
+/**
+ * @dev See {ISwapFactory-Asset}.
+ *
+ * @param addr The address of the target contract.
+ * @param amountOrId The amount of ERC20 tokens or the id of ERC721.
+ */
+export interface Asset {
+	addr: string;
+	amountOrId: bigint;
+}
+
+/**
+ * @dev See {ISwap-Swap}.
+ *
+ * @param owner The owner of the swap.
+ * @param allowed The address that is allowed to execute the swap.
+ * @param expiry The expiry date of the swap.
+ * @param biding The assets that are being bided by the owner.
+ * @param asking The assets that are being asked by the owner.
+ */
+export interface Swap {
+	owner: string;
+	allowed: string;
+	expiry: bigint;
+	biding: Asset[];
+	asking: Asset[];
+}
+
+/**
+ * @dev See {ISwapFactory-makeAsset}.
+ */
+export async function makeAsset(
+	addr: string,
+	amountOrId: number | bigint
+): Promise<Asset> {
+	// validate if its an ethereum address
+	if (isValidAddr(addr)) {
+		throw new Error("InvalidAddressFormat");
+	}
+
+	// if the amount is negative, it will throw an error
+	if (amountOrId < 0) {
+		throw new Error("AmountOrIdCannotBeNegative");
+	}
+
+	/**
+	 * @dev Create a new Asset type described by the contract interface.
+	 *
+	 * NOTE: If the amount is in number format, it will be converted to bigint.
+	 * EVM works with a lot of decimals and might overload using number type.
+	 */
+	const asset: Asset = {
+		addr: addr,
+		amountOrId: typeof amountOrId == "number" ? BigInt(amountOrId) : amountOrId,
+	};
+
+	return asset;
+}
+
+/**
+ * @dev See {ISwapFactory-makeSwap}.
+ */
+export async function makeSwap(
+	owner: any,
+	allowed: any,
+	expiry: any,
+	biding: Asset[],
+	asking: Asset[]
+) {
+	// owner cannot be the zero address, it will always be the `msg.sender`
+	if (owner == ethers.constants.AddressZero) {
+		throw new Error("InvalidOwnerAddress");
+	}
+
+	// check for the current `block.timestamp` because `expiry` cannot be in the past
+	const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
+	if (expiry < timestamp) {
+		throw new Error("InvalidExpiryDate");
+	}
+
+	/**
+	 * @dev one of the swapped assets should never be empty or it should be directly
+	 * transfered using {ERC20-transferFrom} or {ERC721-safeTransferFrom}
+	 *
+	 * NOTE: if the purpose of the swap is to transfer the asset directly using Swaplace,
+	 * then any small token quantity should be used as the swap asset.
+	 */
+	if (biding.length == 0 || asking.length == 0) {
+		throw new Error("InvalidAssetsLength");
+	}
+
+	const swap: Swap = {
+		owner: owner,
+		allowed: allowed,
+		expiry: expiry,
+		biding: biding,
+		asking: asking,
+	};
+
+	return swap;
+}
+
+/**
+ * @dev Facilitate to create a swap when the swap is too large.
+ *
+ * Directly composing swaps to avoid to calling {ISwapFactory-makeAsset}
+ * multiple times.
+ *
+ * NOTE:
+ *
+ * - This function is not implemented in the contract.
+ * - This function needs to be async because it calls for `block.timestamp`.
+ *
+ * Requirements:
+ *
+ * - `owner` cannot be the zero address.
+ * - `expiry` cannot be in the past timestamp.
+ * - `bidingAddr` and `askingAddr` cannot be empty.
+ * - `bidingAddr` and `bidingAmountOrId` must have the same length.
+ * - `askingAddr` and `askingAmountOrId` must have the same length.
+ */
+export async function composeSwap(
+	owner: any,
+	allowed: any,
+	expiry: any,
+	bidingAddr: any[],
+	bidingAmountOrId: any[],
+	askingAddr: any[],
+	askingAmountOrId: any[]
+) {
+	// lenght of addresses and their respective amounts must be equal
+	if (
+		bidingAddr.length != bidingAmountOrId.length ||
+		askingAddr.length != askingAmountOrId.length
+	) {
+		throw new Error("InvalidAssetsLength");
+	}
+
+	// push new assets to the array of bids and asks
+	const biding: any[] = [];
+	bidingAddr.forEach(async (addr, index) => {
+		biding.push(await makeAsset(addr, bidingAmountOrId[index]));
+	});
+
+	const asking: any[] = [];
+	askingAddr.forEach(async (addr, index) => {
+		asking.push(await makeAsset(addr, askingAmountOrId[index]));
+	});
+
+	return await makeSwap(owner, allowed, expiry, biding, asking);
+}
+
+module.exports = {
+	makeAsset,
+	makeSwap,
+	composeSwap,
+};

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -1,0 +1,12 @@
+import { ethers } from "hardhat";
+
+/**
+ * @dev Validates if the address is a valid ethereum address.
+ */
+export function isValidAddr(addr: string): boolean {
+	return !/^0x[a-fA-F0-9]{40}$/gm.test(addr);
+}
+
+module.exports = {
+	isValidAddr,
+};


### PR DESCRIPTION
- delete composeSwap from contracts
- create composeSwap on lib
- adapt all tests using composeSwap
- created utils.ts
- created swapfactory.ts

close #15 