### PR TITLE
refactor: remove unnecessary custom errors from SwapFactory and import the error interface

### DIFF
--- a/contracts/SwapFactory.sol
+++ b/contracts/SwapFactory.sol
@@ -1,14 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
+import {IErrors} from "./interfaces/IErrors.sol";
 import {ISwap} from "./interfaces/ISwap.sol";
 import {ISwapFactory} from "./interfaces/ISwapFactory.sol";
-
-error InvalidAddress(address caller);
-error InvalidAmount(uint256 amount);
-error InvalidAssetsLength();
-error InvalidExpiryDate(uint256 timestamp);
-error InvalidMismatchingLengths(uint256 addr, uint256 amountOrId);
 
 /**
  * @dev - SwapFactory is a helper for creating swaps and making asset structs.
@@ -38,7 +33,7 @@ error InvalidMismatchingLengths(uint256 addr, uint256 amountOrId);
  * in an a trusted contract and swap as an ERC721. But you don't have to stop there,
  * by delegating ownership over a contract, you can tokenize any on-chain execution.
  */
-abstract contract SwapFactory is ISwapFactory, ISwap {
+abstract contract SwapFactory is ISwapFactory, ISwap, IErrors {
     /**
      * @dev Constructs an asset struct that works for ERC20 or ERC721.
      * This function is a utility to easily create an `Asset` struct on memory or off-chain.

--- a/contracts/interfaces/IErrors.sol
+++ b/contracts/interfaces/IErrors.sol
@@ -7,9 +7,18 @@ interface IErrors {
      */
     error InvalidAddress(address caller);
 
+    /**
+     * @dev Displayed when the amount of {ISwap-Asset} has a length of zero.
+     *
+     * NOTE: The `biding` or `asking` array must not be empty to avoid mistakes
+     * when creating a swap. Assuming one side of the swap is empty, the
+     * correct approach should be the usage of {transferFrom} and we reinforce
+     * this behavior by requiring the length of the array to be bigger than zero.
+     */
     error InvalidAssetsLength();
 
+    /**
+     * @dev Displayed when the `expiry` date is in the past.
+     */
     error InvalidExpiryDate(uint256 timestamp);
-
-    error InvalidFunctionCall(bytes reason);
 }


### PR DESCRIPTION
- removed the function call error as it doesn't exist anymore
- added natspec descriptions to the errors interface
- added the library and the implementation to swap factory

close #39