### PR TITLE
feat: fetch current timestamp of hardhat network session and add to utils script

### DIFF
--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -9,6 +9,7 @@ import {
 	makeSwap,
 	composeSwap,
 } from "./utils/SwapFactory";
+import { blocktimestamp } from "./utils/utils";
 
 describe("Swaplace", async function () {
 	let Swaplace: Contract;
@@ -57,9 +58,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should be able to create a swap", async function () {
-		// get current block timestamp
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -106,8 +105,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should be able to cancel swaps", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -136,8 +134,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should not be able to cancel not owned swaps", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -168,8 +165,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should not be able to cancel expired swaps", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -203,8 +199,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should revert when accepting swaps with expiration done", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -246,8 +241,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -299,8 +294,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -343,8 +338,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -386,8 +381,8 @@ describe("Swaplace", async function () {
 		await MockERC20.mintTo(acceptee.address, 2000);
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -436,8 +431,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC721.address];
 		const bidingAmountOrId = [tokenId - 1];
@@ -492,8 +487,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -557,8 +552,8 @@ describe("Swaplace", async function () {
 		const tokenId = await MockERC721.totalSupply();
 
 		// Build the Swap
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address, MockERC721.address];
 		const bidingAmountOrId = [1000, tokenId - 1];

--- a/test/TestTradeFactory.test.ts
+++ b/test/TestTradeFactory.test.ts
@@ -9,6 +9,7 @@ import {
 	makeSwap,
 	composeSwap,
 } from "./utils/SwapFactory";
+import { blocktimestamp } from "./utils/utils";
 
 describe("Swaplace", async function () {
 	let Swaplace: Contract;
@@ -59,8 +60,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should be able to build swaps with one item for both { ERC20, ERC721 }", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const ERC20Asset: Asset = await makeAsset(MockERC20.address, 1000);
 		const ERC721Asset: Asset = await makeAsset(MockERC721.address, 1);
@@ -94,8 +94,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should be able to build composed swap containing both { ERC20, ERC721 }", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const ERC20Asset = await makeAsset(MockERC20.address, 1000);
 		const ERC721Asset = await makeAsset(MockERC721.address, 1);
@@ -117,8 +116,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should be able to compose a swap in a single function for both { ERC20, ERC721 }", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address, MockERC721.address];
 		const bidingAmountOrId = [1000, 1];
@@ -165,8 +163,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should revert while building swap with 'owner' as address zero", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -190,8 +187,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should revert while creating swaps not belonging to msg.sender", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -216,8 +212,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should revert while creating swap with empty assets", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];
@@ -241,8 +236,7 @@ describe("Swaplace", async function () {
 	});
 
 	it("Should revert while composing swap with mismatching inputs length", async function () {
-		const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-		const expiry = timestamp + day * 2;
+		const expiry = (await blocktimestamp()) + day * 2;
 
 		const bidingAddr = [MockERC20.address];
 		const bidingAmountOrId = [1000];

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -7,6 +7,18 @@ export function isValidAddr(addr: string): boolean {
 	return !/^0x[a-fA-F0-9]{40}$/gm.test(addr);
 }
 
+/**
+ * @dev Get the current `block.timestamp` in seconds from the current
+ * selected network.
+ *
+ * Use `-- network localhost` to run the tests in a local network.
+ * Networks should be in `hardhat.config.ts` file or via command line.
+ */
+export async function blocktimestamp(): Promise<number> {
+	return (await ethers.provider.getBlock("latest")).timestamp;
+}
+
 module.exports = {
 	isValidAddr,
+	blocktimestamp,
 };


### PR DESCRIPTION
- added a method for getting block timestamp in `utils.ts`
- changed the timestamp approach from the tests into calling the utils lib

close #42