### PR TITLE
refactor: `swapId` variable changed to `_totalSwaps` / `totalSwaps` getter function added 

### DIFF
--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {IERC165} from './interfaces/IERC165.sol';
-import {ISwaplace} from './interfaces/ISwaplace.sol';
-import {ITransfer} from './interfaces/ITransfer.sol';
-import {SwapFactory} from './SwapFactory.sol';
+import {IERC165} from "./interfaces/IERC165.sol";
+import {ISwaplace} from "./interfaces/ISwaplace.sol";
+import {ITransfer} from "./interfaces/ITransfer.sol";
+import {SwapFactory} from "./SwapFactory.sol";
 
 /**  ___ _    ___   ___ _  _____ _   _ _
  *  | _ ) |  / _ \ / __| |/ / __| | | | |

--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {IERC165} from "./interfaces/IERC165.sol";
-import {ISwaplace} from "./interfaces/ISwaplace.sol";
-import {ITransfer} from "./interfaces/ITransfer.sol";
-import {SwapFactory} from "./SwapFactory.sol";
+import {IERC165} from './interfaces/IERC165.sol';
+import {ISwaplace} from './interfaces/ISwaplace.sol';
+import {ITransfer} from './interfaces/ITransfer.sol';
+import {SwapFactory} from './SwapFactory.sol';
 
 /**  ___ _    ___   ___ _  _____ _   _ _
  *  | _ ) |  / _ \ / __| |/ / __| | | | |
@@ -18,7 +18,7 @@ import {SwapFactory} from "./SwapFactory.sol";
  */
 contract Swaplace is SwapFactory, ISwaplace, IERC165 {
     /// @dev Swap Identifier counter.
-    uint256 public swapId;
+    uint256 private _totalSwaps;
 
     /// @dev Mapping of `swapId` to Swap struct. See {ISwap-Swap}.
     mapping(uint256 => Swap) private swaps;
@@ -39,16 +39,14 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
             revert InvalidAssetsLength();
         }
 
-        unchecked 
-        {
-            assembly 
-            {
-                sstore(swapId.slot, add(sload(swapId.slot), 1))
+        unchecked {
+            assembly {
+                sstore(_totalSwaps.slot, add(sload(_totalSwaps.slot), 1))
             }
         }
 
         //l_ indicating it's a local variable
-        uint256 l_swapId=swapId;
+        uint256 l_swapId = _totalSwaps;
 
         swaps[l_swapId] = swap;
 
@@ -139,5 +137,12 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
         return
             interfaceID == type(IERC165).interfaceId ||
             interfaceID == type(ISwaplace).interfaceId;
+    }
+
+    /**
+     * @dev Getter function for _totalSwaps.
+     */
+    function totalSwaps() public view returns (uint256) {
+        return _totalSwaps;
     }
 }

--- a/contracts/echidna/TestSwaplace.sol
+++ b/contracts/echidna/TestSwaplace.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import '../echidna/TestSwapFactory.sol';
-import '../mock/MockERC20.sol';
-import '../Swaplace.sol';
+import "../echidna/TestSwapFactory.sol";
+import "../mock/MockERC20.sol";
+import "../Swaplace.sol";
 
 contract TestSwaplace is TestFactory {
     MockERC20 private _token;

--- a/contracts/echidna/TestSwaplace.sol
+++ b/contracts/echidna/TestSwaplace.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "../echidna/TestSwapFactory.sol";
-import "../mock/MockERC20.sol";
-import "../Swaplace.sol";
+import '../echidna/TestSwapFactory.sol';
+import '../mock/MockERC20.sol';
+import '../Swaplace.sol';
 
 contract TestSwaplace is TestFactory {
     MockERC20 private _token;
@@ -16,7 +16,7 @@ contract TestSwaplace is TestFactory {
     }
 
     function echidna_create_swap() public returns (bool) {
-        uint256 initId = _swaplace.swapId();
+        uint256 initId = _swaplace.totalSwaps();
 
         uint256 id = _swaplace.createSwap(
             make_valid_swap(address(this), address(_token), 100)
@@ -31,19 +31,19 @@ contract TestSwaplace is TestFactory {
         echidna_create_swap();
         _token.approve(address(_swaplace), type(uint256).max);
 
-        uint256 lastId = _swaplace.swapId();
+        uint256 lastId = _swaplace.totalSwaps();
         return (_swaplace.acceptSwap(lastId));
     }
 
     function echidna_id_overflow() public view returns (bool) {
-        return _swaplace.swapId() < type(uint256).max;
+        return _swaplace.totalSwaps() < type(uint256).max;
     }
 
     function echidna_id_never_zero_after_init() public view returns (bool) {
         Swaplace.Swap memory swap = _swaplace.getSwap(0);
         return
             swap.owner == address(0)
-                ? _swaplace.swapId() == 0
-                : _swaplace.swapId() != 0;
+                ? _swaplace.totalSwaps() == 0
+                : _swaplace.totalSwaps() != 0;
     }
 }

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -72,7 +72,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 
 			it("Should be able to create a 1-N swap with ERC20", async function () {
@@ -98,7 +98,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 
 			it("Should be able to create a N-N swap with ERC20", async function () {
@@ -128,7 +128,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 
 			it("Should be able to create a 1-1 swap with ERC721", async function () {
@@ -150,7 +150,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 
 			it("Should be able to create a 1-N swap with ERC721", async function () {
@@ -176,7 +176,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 
 			it("Should be able to create a N-N swap with ERC721", async function () {
@@ -206,7 +206,7 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 			});
 		});
 
@@ -273,10 +273,10 @@ describe("Swaplace", async function () {
 			it("Should be able to {acceptSwap} as 1-1 Swap", async function () {
 				await Swaplace.connect(owner).createSwap(swap);
 				await expect(
-					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.emit(Swaplace, "SwapAccepted")
-					.withArgs(await Swaplace.swapId(), acceptee.address);
+					.withArgs(await Swaplace.totalSwaps(), acceptee.address);
 			});
 
 			it("Should be able to {acceptSwap} as N-N Swap", async function () {
@@ -300,13 +300,13 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 
 				await expect(
-					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.emit(Swaplace, "SwapAccepted")
-					.withArgs(await Swaplace.swapId(), acceptee.address);
+					.withArgs(await Swaplace.totalSwaps(), acceptee.address);
 			});
 
 			it("Should be able to {acceptSwap} as P2P Swap", async function () {
@@ -321,13 +321,13 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 
 				await expect(
-					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.emit(Swaplace, "SwapAccepted")
-					.withArgs(await Swaplace.swapId(), acceptee.address);
+					.withArgs(await Swaplace.totalSwaps(), acceptee.address);
 			});
 		});
 
@@ -336,13 +336,13 @@ describe("Swaplace", async function () {
 				await Swaplace.connect(owner).createSwap(swap);
 
 				await expect(
-					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					await Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.emit(Swaplace, "SwapAccepted")
-					.withArgs(await Swaplace.swapId(), acceptee.address);
+					.withArgs(await Swaplace.totalSwaps(), acceptee.address);
 
 				await expect(
-					Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.be.revertedWithCustomError(Swaplace, `InvalidExpiry`)
 					.withArgs(0);
@@ -354,7 +354,7 @@ describe("Swaplace", async function () {
 				await network.provider.send("evm_increaseTime", [swap.expiry * 2]);
 
 				await expect(
-					Swaplace.connect(owner).acceptSwap(await Swaplace.swapId())
+					Swaplace.connect(owner).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.be.revertedWithCustomError(Swaplace, `InvalidExpiry`)
 					.withArgs(swap.expiry);
@@ -366,7 +366,7 @@ describe("Swaplace", async function () {
 				await Swaplace.connect(owner).createSwap(swap);
 
 				await expect(
-					Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				).to.be.revertedWith(`ERC721: caller is not token owner or approved`);
 			});
 
@@ -382,10 +382,10 @@ describe("Swaplace", async function () {
 
 				await expect(await Swaplace.connect(owner).createSwap(swap))
 					.to.emit(Swaplace, "SwapCreated")
-					.withArgs(await Swaplace.swapId(), owner.address, swap.expiry);
+					.withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
 
 				await expect(
-					Swaplace.connect(acceptee).acceptSwap(await Swaplace.swapId())
+					Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps())
 				)
 					.to.be.revertedWithCustomError(Swaplace, "InvalidAddress")
 					.withArgs(acceptee.address);
@@ -402,14 +402,14 @@ describe("Swaplace", async function () {
 			});
 
 			it("Should be able to {cancelSwap} a Swap", async function () {
-				const lastSwap = await Swaplace.swapId();
+				const lastSwap = await Swaplace.totalSwaps();
 				expect(await Swaplace.connect(owner).cancelSwap(lastSwap))
 					.to.emit(Swaplace, "SwapCanceled")
 					.withArgs(lastSwap, swap.owner);
 			});
 
 			it("Should not be able to {acceptSwap} a canceled a Swap", async function () {
-				const lastSwap = await Swaplace.swapId();
+				const lastSwap = await Swaplace.totalSwaps();
 				await expect(Swaplace.connect(owner).acceptSwap(lastSwap))
 					.to.be.revertedWithCustomError(Swaplace, `InvalidExpiry`)
 					.withArgs(0);
@@ -424,7 +424,7 @@ describe("Swaplace", async function () {
 			});
 
 			it("Should revert when {owner} is not {msg.sender}", async function () {
-				const lastSwap = await Swaplace.swapId();
+				const lastSwap = await Swaplace.totalSwaps();
 				await expect(Swaplace.connect(acceptee).cancelSwap(lastSwap))
 					.to.be.revertedWithCustomError(Swaplace, `InvalidAddress`)
 					.withArgs(acceptee.address);
@@ -433,7 +433,7 @@ describe("Swaplace", async function () {
 			it("Should revert when {expiry} is smaller than {block.timestamp}", async function () {
 				await network.provider.send("evm_increaseTime", [swap.expiry * 2]);
 
-				const lastSwap = await Swaplace.swapId();
+				const lastSwap = await Swaplace.totalSwaps();
 				await expect(Swaplace.connect(owner).cancelSwap(lastSwap))
 					.to.be.revertedWithCustomError(Swaplace, `InvalidExpiry`)
 					.withArgs(swap.expiry);
@@ -470,7 +470,7 @@ describe("Swaplace", async function () {
 		});
 
 		it("Should be able to {getSwap}", async function () {
-			const lastSwap = await Swaplace.swapId();
+			const lastSwap = await Swaplace.totalSwaps();
 			const fetchedSwap = await Swaplace.getSwap(lastSwap);
 
 			expect(fetchedSwap.owner).not.to.be.equals(zeroAddress);


### PR DESCRIPTION
closes #120 

- I renamed the `swapId` inside `Swaplace.sol` to `_totalSwaps`
- I added the `totalSwaps` getter function at the end of the `Swaplace.sol` smart contract.
- I used NatSpec format to write a brief description for the function
- I renamed the `swapId` calls inside `TestSwaplace.test.ts` and `TestSwaplace.sol` to `totalSwaps`

Obs: In order to successfully run `yarn test` I had to improve the hardhat's solidity version to `0.8.20` due to the new interfaces inside the mock folder added previously, but I am not pushing the hardhat changes. Should I do it?

