### PR TITLE
fix: hardcoding deployer address to config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,11 +4,10 @@ import "solidity-docgen"
 import dotenv from "dotenv"
 dotenv.config()
 
-const {
-    DEPLOYER_PRIVATE_KEY,
-    SWAP_CREATOR_PRIVATE_KEY,
-    SWAP_ACCEPTEE_PRIVATE_KEY,
-} = process.env
+const { SWAP_CREATOR_PRIVATE_KEY, SWAP_ACCEPTEE_PRIVATE_KEY } = process.env
+
+const DEPLOYER_PRIVATE_KEY =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 const config: HardhatUserConfig = {
     solidity: "0.8.17",


### PR DESCRIPTION
GitHub is not correctly fetching vars from the environment when Pull Requests are testing with actions.
This is a temporary solution until we find out why.

closes #145 