### PR TITLE
[ISSUE-121] docs: research gas and cost efficiency for event emission

### DIFF
--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.17;
 import {IERC165} from "./interfaces/IERC165.sol";
 import {ISwaplace} from "./interfaces/ISwaplace.sol";
 import {ITransfer} from "./interfaces/ITransfer.sol";
-import {ISwap} from "./interfaces/ISwap.sol";
 import {SwapFactory} from "./SwapFactory.sol";
 
 /**
@@ -18,26 +17,26 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
   /// @dev Swap Identifier counter.
   uint256 private _totalSwaps;
 
-      /**
-     * @dev Emitted when a new Swap is created.
-     * keccak-256(SwapCreated(uint256,address,uint256,address))
-     */
-    bytes32 private constant EVENT_SWAP_CREATED_SIGNATURE =
-        0x43a58bfac3282e5ce3bfd714c5bc0ddff8d6f2cd049db0b02a25d7cdd5026efb;
+  /**
+   * @dev Emitted when a new Swap is created.
+   * keccak-256(SwapCreated(uint256,address,uint256,address))
+   */
+  bytes32 private constant EVENT_SWAP_CREATED_SIGNATURE =
+    0x43a58bfac3282e5ce3bfd714c5bc0ddff8d6f2cd049db0b02a25d7cdd5026efb;
 
-    /**
-     * @dev Emitted when a Swap is accepted.
-     * keccak-256(SwapAccepted(uint256,address))
-     */
-    bytes32 private constant EVENT_SWAP_ACCEPTED_SIGNATURE =
-        0x38eced64b5c4ab50bb61d2f5fcace3c629a2d92f974374bf4a4f3e8a7c49caef;
+  /**
+   * @dev Emitted when a Swap is accepted.
+   * keccak-256(SwapAccepted(uint256,address))
+   */
+  bytes32 private constant EVENT_SWAP_ACCEPTED_SIGNATURE =
+    0x38eced64b5c4ab50bb61d2f5fcace3c629a2d92f974374bf4a4f3e8a7c49caef;
 
-    /**
-     * @dev Emitted when a Swap is canceled.
-     * keccak-256(SwapCanceled(uint256,address))
-     */
-    bytes32 private constant EVENT_SWAP_CANCELED_SIGNATURE =
-        0x0a01e988a96145b1dd49cafc687666a0525e6b929299df4652cc646915e696d8;
+  /**
+   * @dev Emitted when a Swap is canceled.
+   * keccak-256(SwapCanceled(uint256,address))
+   */
+  bytes32 private constant EVENT_SWAP_CANCELED_SIGNATURE =
+    0x0a01e988a96145b1dd49cafc687666a0525e6b929299df4652cc646915e696d8;
 
   /// @dev Mapping of Swap ID to Swap struct. See {ISwap-Swap}.
   mapping(uint256 => Swap) private _swaps;

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -7,6 +7,7 @@ import {ISwap} from "./ISwap.sol";
  * @dev Interface of the {Swaplace} implementation.
  */
 interface ISwaplace {
+<<<<<<< HEAD
 
   /**
    * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.
@@ -53,6 +54,20 @@ interface ISwaplace {
    * Emits a {SwapCanceled} event.
    */
   function cancelSwap(uint256 swapId) external;
+=======
+    /**
+     * @dev Allow users to create a Swap. Each new Swap self-increments its id by one.
+     *
+     * Requirements:
+     *
+     * - `owner` must be the caller address.
+     * - `expiry` should be bigger than timestamp.
+     * - `biding` and `asking` must not be empty.
+     *
+     * Emits a {SwapCreated} event.
+     */
+    function createSwap(ISwap.Swap calldata Swap) external returns (uint256);
+>>>>>>> a7ca232 (refactor: Remove unecessary import and move the declarion of events signatures)
 
   /**
    * @dev Retrieves the details of a Swap based on the `swapId` provided.

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -7,7 +7,25 @@ import {ISwap} from "./ISwap.sol";
  * @dev Interface of the {Swaplace} implementation.
  */
 interface ISwaplace {
-<<<<<<< HEAD
+  /**
+   * @dev Emitted when a new Swap is created.
+   */
+  event SwapCreated(
+    uint256 indexed swapId,
+    address indexed owner,
+    address indexed allowed,
+    uint256 expiry
+  );
+
+  /**
+   * @dev Emitted when a Swap is accepted.
+   */
+  event SwapAccepted(uint256 indexed swapId, address indexed acceptee);
+
+  /**
+   * @dev Emitted when a Swap is canceled.
+   */
+  event SwapCanceled(uint256 indexed swapId, address indexed owner);
 
   /**
    * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.
@@ -54,20 +72,6 @@ interface ISwaplace {
    * Emits a {SwapCanceled} event.
    */
   function cancelSwap(uint256 swapId) external;
-=======
-    /**
-     * @dev Allow users to create a Swap. Each new Swap self-increments its id by one.
-     *
-     * Requirements:
-     *
-     * - `owner` must be the caller address.
-     * - `expiry` should be bigger than timestamp.
-     * - `biding` and `asking` must not be empty.
-     *
-     * Emits a {SwapCreated} event.
-     */
-    function createSwap(ISwap.Swap calldata Swap) external returns (uint256);
->>>>>>> a7ca232 (refactor: Remove unecessary import and move the declarion of events signatures)
 
   /**
    * @dev Retrieves the details of a Swap based on the `swapId` provided.

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -7,24 +7,6 @@ import {ISwap} from "./ISwap.sol";
  * @dev Interface of the {Swaplace} implementation.
  */
 interface ISwaplace {
-  /**
-   * @dev Emitted when a new Swap is created.
-   */
-  event SwapCreated(
-    uint256 indexed swapId,
-    address indexed owner,
-    uint256 indexed expiry
-  );
-
-  /**
-   * @dev Emitted when a Swap is accepted.
-   */
-  event SwapAccepted(uint256 indexed swapId, address indexed acceptee);
-
-  /**
-   * @dev Emitted when a Swap is canceled.
-   */
-  event SwapCanceled(uint256 indexed swapId, address indexed owner);
 
   /**
    * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.

--- a/docs/interfaces/ISwaplace.md
+++ b/docs/interfaces/ISwaplace.md
@@ -7,7 +7,7 @@ Interface of the {Swaplace} implementation.
 ### SwapCreated
 
 ```solidity
-event SwapCreated(uint256 swapId, address owner, uint256 expiry)
+event SwapCreated(uint256 swapId, address owner, address allowed, uint256 expiry)
 ```
 
 Emitted when a new Swap is created.

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -72,7 +72,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
 
       it("Should be able to create a 1-N swap with ERC20", async function () {
@@ -98,7 +98,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
 
       it("Should be able to create a N-N swap with ERC20", async function () {
@@ -128,7 +128,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
 
       it("Should be able to create a 1-1 swap with ERC721", async function () {
@@ -150,7 +150,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
 
       it("Should be able to create a 1-N swap with ERC721", async function () {
@@ -176,7 +176,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
 
       it("Should be able to create a N-N swap with ERC721", async function () {
@@ -206,7 +206,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
       });
     });
 
@@ -302,7 +302,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -325,7 +325,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -390,7 +390,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.expiry);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, swap.allowed, swap.expiry);
 
         await expect(
           Swaplace.connect(acceptee).acceptSwap(await Swaplace.totalSwaps()),


### PR DESCRIPTION
# docs: research gas and cost efficiency for event emission 
closes #121 

## How I calculated the gas usage?

- Example:

```
uint256 startGas = gasleft();

// code

gasUsed = startGas - gasleft();
```

## Prepare a spreadsheet with the gas usage based on the current and proposed events emitted and set for a comparison.

- In the document I separeted a comparison about the options to emit events :)

## Estimate the gas when calling createSwap and record their gas usage.

- When we call the "createSwap" event with the current parameters (id, owner and expiry) the gas usage is 1932.

```
event SwapCreated(
    uint256 indexed id,
    address indexed owner,
    uint256 indexed expiry
);
```

```
emit SwapCreated(swapId, msg.sender, swap.expiry);
```

- But we can optimize with assembly, so the gas usage can be: 1919

```
//keccak-256(SwapCreated(uint256,address,uint256))
bytes32 private constant EVENT_SWAP_CREATED_SIGNATURE =
    0xecac413765eac3982e66e569ad3a200e6b3f188ac4d7d44cc5da667779ca8d05;
```

```
uint256 swapExpiry = swap.expiry;
assembly {
    log4(0x00, 0x00, EVENT_SWAP_CREATED_SIGNATURE, swapId, caller(), swapExpiry)
}
```

## Take measures of the gas usage.

- I change the emit of events to use assembly to reduce the gas usage.

## Add the allowed field in the events. Take Measure.

- Gas usage with Solidity: 2702

```
event SwapCreated(
    uint256 indexed id,
    address indexed owner,
    uint256 indexed expiry,
    address allowed
);
```

``` 
emit SwapCreated(swapId, msg.sender, swap.expiry, swap.allowed);
```

- But we can optimize with assembly, so the gas usage can be: 2502

```
//keccak-256(SwapCreated(uint256,address,uint256,address))
bytes32 private constant EVENT_SWAP_CREATED_SIGNATURE =
    0x43a58bfac3282e5ce3bfd714c5bc0ddff8d6f2cd049db0b02a25d7cdd5026efb;
```

```
uint256 swapExpiry = swap.expiry;
address allowed = swap.allowed;
assembly {
    mstore(0x00, allowed)
    log4(0x00, 0x20, EVENT_SWAP_CREATED_SIGNATURE, swapId, caller(), swapExpiry)
}
```

## Add the bidding and asking field in the events. Take Measure.

- Gas usage with Solidity: 7646

```
event SwapCreated(
    uint256 indexed id,
    address indexed owner,
    uint256 indexed expiry,
    address allowed,
    ISwap.Asset[] biding,
    ISwap.Asset[] asking
);
```

```
emit SwapCreated(swapId, msg.sender, swap.expiry, swap.allowed, swap.biding, swap.asking);
```

## Add the price of ETH at $2.200 and calculate the gas cost in dollars.

- I don't know how I can make this setting the ETH value. (help me please :) 

# Conclusion

- After the study about gas usage in the swaplace, I came to the conclusion that we can add the "allowed" field in the "SwapCreated" event, but if we add the "biding" and "asking" fields, we will increase a lot the gas usage in the emit of events, so I this PR I added the "allowed" field in the swap created event and refactored all events to use assembly to reduce the gas usage.

- And about the "biding" and "asking" fields, I think that is have a lot of gas usage and I'm studying about how we can emit the event with assembly there paramters, I tried but I couldn't, I'm trying yet :)

- If possible, I need your review about this PR :), I'm ready to fix/improve something and work togheter!!!