### PR TITLE
refactor: changed id variable into swapId

### DIFF
--- a/contracts/SwapFactory.sol
+++ b/contracts/SwapFactory.sol
@@ -26,7 +26,7 @@ import {ISwapFactory} from "./interfaces/ISwapFactory.sol";
  *
  * - The `address` of the asset. This address can be from an ERC20 or ERC721 contract.
  * - The `amount` or `id` of the asset. This amount can be the amount of ERC20 tokens
- *  or the id of an ERC721 token.
+ *  or the ID of an ERC721 token.
  *
  * To use other standards, like ERC1155, you can wrap the ownership of the asset
  * in an a trusted contract and Swap as an ERC721. This way, you can tokenize any

--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -54,8 +54,8 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
   /**
    * @dev See {ISwaplace-acceptSwap}.
    */
-  function acceptSwap(uint256 id) public returns (bool) {
-    Swap memory swap = _swaps[id];
+  function acceptSwap(uint256 swapId) public returns (bool) {
+    Swap memory swap = _swaps[swapId];
 
     if (swap.allowed != address(0) && swap.allowed != msg.sender) {
       revert InvalidAddress(msg.sender);
@@ -65,7 +65,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
       revert InvalidExpiry(swap.expiry);
     }
 
-    _swaps[id].expiry = 0;
+    _swaps[swapId].expiry = 0;
 
     Asset[] memory assets = swap.asking;
 
@@ -93,7 +93,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
       }
     }
 
-    emit SwapAccepted(id, msg.sender);
+    emit SwapAccepted(swapId, msg.sender);
 
     return true;
   }
@@ -101,8 +101,8 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
   /**
    * @dev See {ISwaplace-cancelSwap}.
    */
-  function cancelSwap(uint256 id) public {
-    Swap memory swap = _swaps[id];
+  function cancelSwap(uint256 swapId) public {
+    Swap memory swap = _swaps[swapId];
 
     if (swap.owner != msg.sender) {
       revert InvalidAddress(msg.sender);
@@ -112,16 +112,16 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
       revert InvalidExpiry(swap.expiry);
     }
 
-    _swaps[id].expiry = 0;
+    _swaps[swapId].expiry = 0;
 
-    emit SwapCanceled(id, msg.sender);
+    emit SwapCanceled(swapId, msg.sender);
   }
 
   /**
    * @dev See {ISwaplace-getSwap}.
    */
-  function getSwap(uint256 id) public view returns (Swap memory) {
-    return _swaps[id];
+  function getSwap(uint256 swapId) public view returns (Swap memory) {
+    return _swaps[swapId];
   }
 
   /**

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -11,7 +11,7 @@ interface ISwaplace {
    * @dev Emitted when a new Swap is created.
    */
   event SwapCreated(
-    uint256 indexed id,
+    uint256 indexed swapId,
     address indexed owner,
     uint256 indexed expiry
   );
@@ -19,15 +19,15 @@ interface ISwaplace {
   /**
    * @dev Emitted when a Swap is accepted.
    */
-  event SwapAccepted(uint256 indexed id, address indexed acceptee);
+  event SwapAccepted(uint256 indexed swapId, address indexed acceptee);
 
   /**
    * @dev Emitted when a Swap is canceled.
    */
-  event SwapCanceled(uint256 indexed id, address indexed owner);
+  event SwapCanceled(uint256 indexed swapId, address indexed owner);
 
   /**
-   * @dev Allow users to create a Swap. Each new Swap self-increments its id by one.
+   * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.
    *
    * Requirements:
    *
@@ -55,7 +55,7 @@ interface ISwaplace {
    * NOTE: The expiry is set to 0, because if the Swap is expired it
    * will revert, preventing reentrancy attacks.
    */
-  function acceptSwap(uint256 id) external returns (bool);
+  function acceptSwap(uint256 swapId) external returns (bool);
 
   /**
    * @dev Cancels an active Swap by setting the expiry to zero.
@@ -70,7 +70,7 @@ interface ISwaplace {
    *
    * Emits a {SwapCanceled} event.
    */
-  function cancelSwap(uint256 id) external;
+  function cancelSwap(uint256 swapId) external;
 
   /**
    * @dev Retrieves the details of a Swap based on the `swapId` provided.
@@ -79,5 +79,5 @@ interface ISwaplace {
    * You can check if a Swap exists by checking if the `owner` is the zero address.
    * If the `owner` is the zero address, then the Swap doesn't exist.
    */
-  function getSwap(uint256 id) external view returns (ISwap.Swap memory);
+  function getSwap(uint256 swapId) external view returns (ISwap.Swap memory);
 }

--- a/docs/SwapFactory.md
+++ b/docs/SwapFactory.md
@@ -10,19 +10,19 @@ used in the {Swaplace-createSwap} function.
 Swaplace uses a {ISwap-Swap} struct to represent a Swap. This struct is
 composed of:
 
--   The `owner` of the Swap is the address that created the Swap.
--   The `allowed` address is the address that can accept the Swap. If the allowed
-    address is the zero address, then anyone can accept the Swap.
--   The `expiry` date is the timestamp that the Swap will be available to accept.
--   The `biding` are the assets that the owner is offering.
--   The `asking` are the assets that the owner wants in exchange.
+- The `owner` of the Swap is the address that created the Swap.
+- The `allowed` address is the address that can accept the Swap. If the allowed
+  address is the zero address, then anyone can accept the Swap.
+- The `expiry` date is the timestamp that the Swap will be available to accept.
+- The `biding` are the assets that the owner is offering.
+- The `asking` are the assets that the owner wants in exchange.
 
 The Swap struct uses an {Asset} struct to represent the asset. This struct is
 composed of:
 
--   The `address` of the asset. This address can be from an ERC20 or ERC721 contract.
--   The `amount` or `id` of the asset. This amount can be the amount of ERC20 tokens
-    or the id of an ERC721 token.
+- The `address` of the asset. This address can be from an ERC20 or ERC721 contract.
+- The `amount` or `id` of the asset. This amount can be the amount of ERC20 tokens
+  or the ID of an ERC721 token.
 
 To use other standards, like ERC1155, you can wrap the ownership of the asset
 in an a trusted contract and Swap as an ERC721. This way, you can tokenize any

--- a/docs/Swaplace.md
+++ b/docs/Swaplace.md
@@ -18,7 +18,7 @@ _See {ISwaplace-createSwap}._
 ### acceptSwap
 
 ```solidity
-function acceptSwap(uint256 id) public returns (bool)
+function acceptSwap(uint256 swapId) public returns (bool)
 ```
 
 _See {ISwaplace-acceptSwap}._
@@ -26,7 +26,7 @@ _See {ISwaplace-acceptSwap}._
 ### cancelSwap
 
 ```solidity
-function cancelSwap(uint256 id) public
+function cancelSwap(uint256 swapId) public
 ```
 
 _See {ISwaplace-cancelSwap}._
@@ -34,7 +34,7 @@ _See {ISwaplace-cancelSwap}._
 ### getSwap
 
 ```solidity
-function getSwap(uint256 id) public view returns (struct ISwap.Swap)
+function getSwap(uint256 swapId) public view returns (struct ISwap.Swap)
 ```
 
 _See {ISwaplace-getSwap}._

--- a/docs/interfaces/ISwaplace.md
+++ b/docs/interfaces/ISwaplace.md
@@ -7,7 +7,7 @@ Interface of the {Swaplace} implementation.
 ### SwapCreated
 
 ```solidity
-event SwapCreated(uint256 id, address owner, uint256 expiry)
+event SwapCreated(uint256 swapId, address owner, uint256 expiry)
 ```
 
 Emitted when a new Swap is created.
@@ -15,7 +15,7 @@ Emitted when a new Swap is created.
 ### SwapAccepted
 
 ```solidity
-event SwapAccepted(uint256 id, address acceptee)
+event SwapAccepted(uint256 swapId, address acceptee)
 ```
 
 Emitted when a Swap is accepted.
@@ -23,7 +23,7 @@ Emitted when a Swap is accepted.
 ### SwapCanceled
 
 ```solidity
-event SwapCanceled(uint256 id, address owner)
+event SwapCanceled(uint256 swapId, address owner)
 ```
 
 Emitted when a Swap is canceled.
@@ -34,20 +34,20 @@ Emitted when a Swap is canceled.
 function createSwap(struct ISwap.Swap Swap) external returns (uint256)
 ```
 
-Allow users to create a Swap. Each new Swap self-increments its id by one.
+Allow users to create a Swap. Each new Swap self-increments its ID by one.
 
 Requirements:
 
--   `owner` must be the caller address.
--   `expiry` should be bigger than timestamp.
--   `biding` and `asking` must not be empty.
+- `owner` must be the caller address.
+- `expiry` should be bigger than timestamp.
+- `biding` and `asking` must not be empty.
 
 Emits a {SwapCreated} event.
 
 ### acceptSwap
 
 ```solidity
-function acceptSwap(uint256 id) external returns (bool)
+function acceptSwap(uint256 swapId) external returns (bool)
 ```
 
 Accepts a Swap. Once the Swap is accepted, the expiry is set
@@ -55,10 +55,10 @@ to zero to avoid reutilization.
 
 Requirements:
 
--   `allowed` must be the zero address or match the caller address.
--   `expiry` must be bigger than timestamp.
--   `biding` assets must be allowed to transfer.
--   `asking` assets must be allowed to transfer.
+- `allowed` must be the zero address or match the caller address.
+- `expiry` must be bigger than timestamp.
+- `biding` assets must be allowed to transfer.
+- `asking` assets must be allowed to transfer.
 
 Emits a {SwapAccepted} event.
 
@@ -68,7 +68,7 @@ will revert, preventing reentrancy attacks.
 ### cancelSwap
 
 ```solidity
-function cancelSwap(uint256 id) external
+function cancelSwap(uint256 swapId) external
 ```
 
 Cancels an active Swap by setting the expiry to zero.
@@ -78,15 +78,15 @@ or is already canceled.
 
 Requirements:
 
--   `owner` must be the caller adress.
--   `expiry` must be bigger than timestamp.
+- `owner` must be the caller adress.
+- `expiry` must be bigger than timestamp.
 
 Emits a {SwapCanceled} event.
 
 ### getSwap
 
 ```solidity
-function getSwap(uint256 id) external view returns (struct ISwap.Swap)
+function getSwap(uint256 swapId) external view returns (struct ISwap.Swap)
 ```
 
 Retrieves the details of a Swap based on the `swapId` provided.

--- a/scripts/acceptSwap.ts
+++ b/scripts/acceptSwap.ts
@@ -11,7 +11,7 @@ export async function main() {
   // Get the Swaplace instance
   const Swaplace = new ethers.Contract(swaplaceAddress, abi.abi, signer);
 
-  // Get the swap id to be accepted
+  // Get the swap ID to be accepted
   const swapId = 1;
 
   // Accept the swap

--- a/scripts/cancelSwap.ts
+++ b/scripts/cancelSwap.ts
@@ -11,7 +11,7 @@ export async function main() {
   // Get the Swaplace instance
   const Swaplace = new ethers.Contract(swaplaceAddress, abi.abi, signer);
 
-  // Get the swap id to be canceled
+  // Get the swap ID to be canceled
   const swapId = 1;
 
   // Cancel the swap

--- a/scripts/getSwap.ts
+++ b/scripts/getSwap.ts
@@ -11,7 +11,7 @@ export async function main() {
   // Get the Swaplace instance
   const Swaplace = new ethers.Contract(swaplaceAddress, abi.abi, signer);
 
-  // Get the swap id
+  // Get the swap ID
   const swapId = 1;
 
   // Get the swap


### PR DESCRIPTION
- changed id on comments into ID uppercase
- changed id into swapId

This is being proposed to preserve legibility across the code and avoid confusion