### PR TITLE
refactor: fixing legibility of timestamp

### DIFF
--- a/test/TestSwapFactory.test.ts
+++ b/test/TestSwapFactory.test.ts
@@ -68,12 +68,12 @@ describe("Swaplace Factory", async function () {
   });
 
   it("Should be able to {makeSwap} in the off-chain matching on-chain", async function () {
-    const expiry = (await blocktimestamp()) * 2;
+    const currentTimestamp = (await blocktimestamp()) * 2;
 
     const ERC20Asset: Asset = await makeAsset(MockERC20.address, 1000);
     const ERC721Asset: Asset = await makeAsset(MockERC721.address, 1);
 
-    const config = await Swaplace.packData(zeroAddress, expiry);
+    const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
     const swap = await makeSwap(
       owner.address,
@@ -82,31 +82,31 @@ describe("Swaplace Factory", async function () {
       [ERC721Asset],
     );
 
-    const onchainSwap = await Swaplace.makeSwap(
+    const onChainSwap = await Swaplace.makeSwap(
       owner.address,
       zeroAddress,
-      expiry,
+      currentTimestamp,
       [ERC20Asset],
       [ERC721Asset],
     );
 
-    const [swapAllowed, swapExpiry] = await Swaplace.parseData(swap.config);
+    const [allowed, expiry] = await Swaplace.parseData(swap.config);
     const [onChainAllowed, onChainExpiry] = await Swaplace.parseData(
-      onchainSwap.config,
+      onChainSwap.config,
     );
 
-    expect(swap.owner).to.be.equals(onchainSwap.owner);
-    expect(swapExpiry).to.be.equals(onChainExpiry);
-    expect(swapAllowed).to.be.equals(onChainAllowed);
+    expect(swap.owner).to.be.equals(onChainSwap.owner);
+    expect(expiry).to.be.equals(onChainExpiry);
+    expect(allowed).to.be.equals(onChainAllowed);
 
-    expect(swap.biding[0].addr).to.be.equals(onchainSwap.biding[0].addr);
+    expect(swap.biding[0].addr).to.be.equals(onChainSwap.biding[0].addr);
     expect(swap.biding[0].amountOrId).to.be.equals(
-      onchainSwap.biding[0].amountOrId,
+      onChainSwap.biding[0].amountOrId,
     );
 
-    expect(swap.asking[0].addr).to.be.equals(onchainSwap.asking[0].addr);
+    expect(swap.asking[0].addr).to.be.equals(onChainSwap.asking[0].addr);
     expect(swap.asking[0].amountOrId).to.be.equals(
-      onchainSwap.asking[0].amountOrId,
+      onChainSwap.asking[0].amountOrId,
     );
   });
 
@@ -187,7 +187,7 @@ describe("Swaplace Factory", async function () {
   });
 
   it("Should revert using {composeSwap} with owner as address zero", async function () {
-    const expiry = (await blocktimestamp()) * 2;
+    const currentTimestamp = (await blocktimestamp()) * 2;
 
     const bidingAddr = [MockERC20.address];
     const bidingAmountOrId = [1000];
@@ -196,7 +196,7 @@ describe("Swaplace Factory", async function () {
     const askingAmountOrId = [2];
 
     try {
-      const config = await Swaplace.packData(zeroAddress, expiry);
+      const config = await Swaplace.packData(zeroAddress, currentTimestamp);
       await composeSwap(
         zeroAddress,
         config,
@@ -211,7 +211,7 @@ describe("Swaplace Factory", async function () {
   });
 
   it("Should revert using {composeSwap} with empty assets", async function () {
-    const expiry = (await blocktimestamp()) * 2;
+    const currentTimestamp = (await blocktimestamp()) * 2;
 
     const bidingAddr = [MockERC20.address];
     const bidingAmountOrId = [1000];
@@ -220,7 +220,7 @@ describe("Swaplace Factory", async function () {
     const askingAmountOrId: any[] = [];
 
     try {
-      const config = await Swaplace.packData(zeroAddress, expiry);
+      const config = await Swaplace.packData(zeroAddress, currentTimestamp);
       await composeSwap(
         owner.address,
         config,
@@ -235,7 +235,7 @@ describe("Swaplace Factory", async function () {
   });
 
   it("Should revert using {composeSwap} with empty assets length", async function () {
-    const expiry = (await blocktimestamp()) * 2;
+    const currentTimestamp = (await blocktimestamp()) * 2;
 
     const bidingAddr = [MockERC20.address];
     const bidingAmountOrId = [1000];
@@ -244,7 +244,7 @@ describe("Swaplace Factory", async function () {
     const askingAmountOrId = [1, 999, 777];
 
     try {
-      const config = await Swaplace.packData(zeroAddress, expiry);
+      const config = await Swaplace.packData(zeroAddress, currentTimestamp);
       await composeSwap(
         owner.address,
         config,

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -32,8 +32,8 @@ describe("Swaplace", async function () {
     const askingAddr = [MockERC20.address];
     const askingAmountOrId = [50];
 
-    const expiry = (await blocktimestamp()) * 2;
-    const config = await Swaplace.packData(zeroAddress, expiry);
+    const currentTimestamp = (await blocktimestamp()) * 2;
+    const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
     const swap: Swap = await composeSwap(
       owner.address,
@@ -63,8 +63,8 @@ describe("Swaplace", async function () {
         const askingAddr = [MockERC20.address];
         const askingAmountOrId = [50];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -81,7 +81,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
 
@@ -96,8 +96,8 @@ describe("Swaplace", async function () {
         ];
         const askingAmountOrId = [50, 100, 150];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -114,7 +114,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
 
@@ -133,8 +133,8 @@ describe("Swaplace", async function () {
         ];
         const askingAmountOrId = [50, 100, 150];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -151,7 +151,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
 
@@ -162,8 +162,8 @@ describe("Swaplace", async function () {
         const askingAddr = [MockERC721.address];
         const askingAmountOrId = [4];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -180,7 +180,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
 
@@ -195,8 +195,8 @@ describe("Swaplace", async function () {
         ];
         const askingAmountOrId = [4, 5, 6];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -213,7 +213,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
 
@@ -232,8 +232,8 @@ describe("Swaplace", async function () {
         ];
         const askingAmountOrId = [4, 5, 6];
 
-        const expiry = (await blocktimestamp()) * 2;
-        const config = await Swaplace.packData(zeroAddress, expiry);
+        const currentTimestamp = (await blocktimestamp()) * 2;
+        const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
         const swap: Swap = await composeSwap(
           owner.address,
@@ -250,7 +250,7 @@ describe("Swaplace", async function () {
             await Swaplace.totalSwaps(),
             owner.address,
             zeroAddress,
-            expiry,
+            currentTimestamp,
           );
       });
     });
@@ -305,8 +305,8 @@ describe("Swaplace", async function () {
       const askingAddr = [MockERC20.address];
       const askingAmountOrId = [1000];
 
-      const expiry = (await blocktimestamp()) * 2;
-      const config = await Swaplace.packData(zeroAddress, expiry);
+      const currentTimestamp = (await blocktimestamp()) * 2;
+      const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
       swap = await composeSwap(
         owner.address,
@@ -558,8 +558,8 @@ describe("Swaplace", async function () {
       const askingAddr = [MockERC20.address];
       const askingAmountOrId = [1000];
 
-      const expiry = (await blocktimestamp()) * 2;
-      const config = await Swaplace.packData(zeroAddress, expiry);
+      const currentTimestamp = (await blocktimestamp()) * 2;
+      const config = await Swaplace.packData(zeroAddress, currentTimestamp);
 
       swap = await composeSwap(
         owner.address,

--- a/test/utils/SwapFactory.ts
+++ b/test/utils/SwapFactory.ts
@@ -62,8 +62,8 @@ export async function makeSwap(
     BigInt(config) & ((BigInt(1) << BigInt(96)) - BigInt(1));
 
   // check for the current `block.timestamp` because `expiry` cannot be in the past
-  const timestamp = (await ethers.provider.getBlock("latest")).timestamp;
-  if (expiry < timestamp) {
+  const currentTimestamp = (await ethers.provider.getBlock("latest")).timestamp;
+  if (expiry < currentTimestamp) {
     throw new Error("InvalidExpiry");
   }
 


### PR DESCRIPTION

## Feature Request

### Describe the Feature Request

Proposing a fix for the overall legibility of timestamp when using the `config` feature of the contract

### Describe Preferred Solution

Changed `expiry` of block.timestamp into `currentTimestamp`. 
`expiry` is now the return variable of the `parseData(swap.config)`
