### PR TITLE
 refactor: Set the value of config as zero directly instead of packing allowed and expiry in the acceptSwap(). #184 

### DIFF
--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -54,7 +54,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
 
     if (expiry < block.timestamp) revert InvalidExpiry(expiry);
 
-    _swaps[swapId].config = packData(allowed, 0);
+    _swaps[swapId].config = 0;
 
     Asset[] memory assets = swap.asking;
 


### PR DESCRIPTION
closes #184 