### PR TITLE
 refactor: events must emit addresses involved in the operation for better dApp indexing #186 

### DIFF
--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -36,7 +36,9 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
 
     _swaps[swapId] = swap;
 
-    emit SwapCreated(swapId);
+    (address allowed,) = parseData(swap.config);
+
+    emit SwapCreated(swapId, swap.owner, allowed);
 
     return swapId;
   }
@@ -90,7 +92,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
       }
     }
 
-    emit SwapAccepted(swapId, msg.sender);
+    emit SwapAccepted(swapId, swap.owner, allowed);
 
     return true;
   }
@@ -107,7 +109,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
 
     _swaps[swapId].config = 0;
 
-    emit SwapCanceled(swapId);
+    emit SwapCanceled(swapId, _swaps[swapId].owner);
   }
 
   /**

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -10,19 +10,17 @@ interface ISwaplace {
   /**
    * @dev Emitted when a new Swap is created.
    */
-  event SwapCreated(
-    uint256 indexed swapId
-  );
+  event SwapCreated(uint256 indexed swapId, address indexed owner, address indexed allowed);
 
   /**
    * @dev Emitted when a Swap is accepted.
    */
-  event SwapAccepted(uint256 indexed swapId, address indexed acceptee);
+  event SwapAccepted(uint256 indexed swapId, address indexed owner, address indexed allowed);
 
   /**
    * @dev Emitted when a Swap is canceled.
    */
-  event SwapCanceled(uint256 indexed swapId);
+  event SwapCanceled(uint256 indexed swapId, address indexed owner);
 
   /**
    * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -77,7 +77,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to create a 1-N swap with ERC20", async function () {
@@ -105,7 +105,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to create a N-N swap with ERC20", async function () {
@@ -137,7 +137,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to create a 1-1 swap with ERC721", async function () {
@@ -161,7 +161,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to create a 1-N swap with ERC721", async function () {
@@ -189,7 +189,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to create a N-N swap with ERC721", async function () {
@@ -221,7 +221,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
     });
 
@@ -276,7 +276,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to {acceptSwap} as N-N Swap", async function () {
@@ -302,7 +302,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -311,7 +311,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(),owner.address, zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
       });
 
       it("Should be able to {acceptSwap} as P2P Swap", async function () {
@@ -329,7 +329,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,allowed);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, allowed);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -338,7 +338,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(),owner.address, allowed);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, allowed);
       });
     });
 
@@ -353,7 +353,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(), owner.address,zeroAddress);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, zeroAddress);
 
         await expect(
           Swaplace.connect(acceptee).acceptSwap(
@@ -410,7 +410,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps(),owner.address,allowed);
+          .withArgs(await Swaplace.totalSwaps(), owner.address, allowed);
 
         await expect(
           Swaplace.connect(acceptee).acceptSwap(
@@ -436,7 +436,7 @@ describe("Swaplace", async function () {
         const lastSwap = await Swaplace.totalSwaps();
         await expect(await Swaplace.connect(owner).cancelSwap(lastSwap))
           .to.emit(Swaplace, "SwapCanceled")
-          .withArgs(lastSwap,owner.address);
+          .withArgs(lastSwap, owner.address);
       });
 
       it("Should not be able to {acceptSwap} a canceled a Swap", async function () {

--- a/test/TestSwaplace.test.ts
+++ b/test/TestSwaplace.test.ts
@@ -77,7 +77,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to create a 1-N swap with ERC20", async function () {
@@ -105,7 +105,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to create a N-N swap with ERC20", async function () {
@@ -137,7 +137,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to create a 1-1 swap with ERC721", async function () {
@@ -161,7 +161,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to create a 1-N swap with ERC721", async function () {
@@ -189,7 +189,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to create a N-N swap with ERC721", async function () {
@@ -221,7 +221,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
     });
 
@@ -276,7 +276,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(), acceptee.address);
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
       });
 
       it("Should be able to {acceptSwap} as N-N Swap", async function () {
@@ -302,7 +302,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,zeroAddress);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -311,7 +311,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(), acceptee.address);
+          .withArgs(await Swaplace.totalSwaps(),owner.address, zeroAddress);
       });
 
       it("Should be able to {acceptSwap} as P2P Swap", async function () {
@@ -329,7 +329,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,allowed);
 
         await expect(
           await Swaplace.connect(acceptee).acceptSwap(
@@ -338,7 +338,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(), acceptee.address);
+          .withArgs(await Swaplace.totalSwaps(),owner.address, allowed);
       });
     });
 
@@ -353,7 +353,7 @@ describe("Swaplace", async function () {
           ),
         )
           .to.emit(Swaplace, "SwapAccepted")
-          .withArgs(await Swaplace.totalSwaps(), acceptee.address);
+          .withArgs(await Swaplace.totalSwaps(), owner.address,zeroAddress);
 
         await expect(
           Swaplace.connect(acceptee).acceptSwap(
@@ -410,7 +410,7 @@ describe("Swaplace", async function () {
 
         await expect(await Swaplace.connect(owner).createSwap(swap))
           .to.emit(Swaplace, "SwapCreated")
-          .withArgs(await Swaplace.totalSwaps());
+          .withArgs(await Swaplace.totalSwaps(),owner.address,allowed);
 
         await expect(
           Swaplace.connect(acceptee).acceptSwap(
@@ -436,7 +436,7 @@ describe("Swaplace", async function () {
         const lastSwap = await Swaplace.totalSwaps();
         await expect(await Swaplace.connect(owner).cancelSwap(lastSwap))
           .to.emit(Swaplace, "SwapCanceled")
-          .withArgs(lastSwap);
+          .withArgs(lastSwap,owner.address);
       });
 
       it("Should not be able to {acceptSwap} a canceled a Swap", async function () {


### PR DESCRIPTION
Closes #186 