### PR TITLE
refactor: events must emit addresses involved in the operation for better dApp indexing #186

### DIFF
--- a/contracts/Swaplace.sol
+++ b/contracts/Swaplace.sol
@@ -36,7 +36,9 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
 
     _swaps[swapId] = swap;
 
-    emit SwapCreated(swapId);
+    (address allowed, ) = parseData(swap.config);
+
+    emit SwapCreated(swapId, msg.sender, allowed);
 
     return swapId;
   }
@@ -90,7 +92,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
       }
     }
 
-    emit SwapAccepted(swapId, msg.sender);
+    emit SwapAccepted(swapId, swap.owner, allowed);
 
     return true;
   }
@@ -107,7 +109,7 @@ contract Swaplace is SwapFactory, ISwaplace, IERC165 {
 
     _swaps[swapId].config = 0;
 
-    emit SwapCanceled(swapId);
+    emit SwapCanceled(swapId, _swaps[swapId].owner);
   }
 
   /**

--- a/contracts/interfaces/ISwaplace.sol
+++ b/contracts/interfaces/ISwaplace.sol
@@ -11,18 +11,23 @@ interface ISwaplace {
    * @dev Emitted when a new Swap is created.
    */
   event SwapCreated(
-    uint256 indexed swapId
+    uint256 indexed swapId,
+    address indexed owner,
+    address indexed allowed
   );
 
   /**
    * @dev Emitted when a Swap is accepted.
    */
-  event SwapAccepted(uint256 indexed swapId, address indexed acceptee);
+  event SwapAccepted(
+    uint256 indexed swapId,
+    address indexed owner,
+    address indexed allowed);
 
   /**
    * @dev Emitted when a Swap is canceled.
    */
-  event SwapCanceled(uint256 indexed swapId);
+  event SwapCanceled(uint256 indexed swapId, address indexed owner);
 
   /**
    * @dev Allow users to create a Swap. Each new Swap self-increments its ID by one.


### PR DESCRIPTION
This PR close #186 

ToDo:

- [x] Renaming acceptee to allowed
- [x] Refactor events in the contract
- [x] Refactor events in the interface
- [x] Refactor events in the unit test