### PR TITLE
fix: comment on make transactions and add transaction mined period

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ compile:
 	yarn compile
 
 ## Please specify which network following the available ones in hardhat.config.ts.
-network=sepolia
+network=localhost
 
 ## Deploying Swaplace contract to the desired network.
 swaplace:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ compile:
 	yarn compile
 
 ## Please specify which network following the available ones in hardhat.config.ts.
-network=localhost
+network=sepolia
 
 ## Deploying Swaplace contract to the desired network.
 swaplace:
@@ -50,7 +50,7 @@ test-suite-runner:
 	make cancel
 
 ## Feed existing Swaplace contract with some transactions.
-## make mint
+## Requires a deployed Swaplace contract and mocks.
 transactions:
 	make mint
 	make approve

--- a/scripts/createSwap.ts
+++ b/scripts/createSwap.ts
@@ -113,6 +113,9 @@ export async function main() {
   /// @dev Store the recently created swap and it's corresponding ID in the `.env` file.
   const swapId = await Swaplace.totalSwaps();
   await storeEnv(swapId, "SWAP_ID", tx.hash);
+
+  /// @dev Awaits for the transaction to be mined.
+  await tx.wait();
 }
 
 main().catch((error) => {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -35,6 +35,9 @@ async function main() {
 
   // @dev Store the contract address in the .env file.
   await storeEnv(Swaplace.address, "SWAPLACE_ADDRESS", true);
+
+  /// @dev Awaits for the transaction to be mined.
+  await Swaplace.deployed();
 }
 
 main().catch((error) => {

--- a/scripts/deployMock.ts
+++ b/scripts/deployMock.ts
@@ -43,9 +43,13 @@ async function main() {
     MockERC721.deployTransaction.hash,
   );
 
-  // @dev Store the contract addresses in the .env file.
+  /// @dev Store the contract addresses in the .env file.
   await storeEnv(MockERC20.address, "ERC20_ADDRESS", true);
   await storeEnv(MockERC721.address, "ERC721_ADDRESS", true);
+
+  /// @dev Awaits for the transaction to be mined.
+  await MockERC20.deployed();
+  await MockERC721.deployed();
 }
 
 main().catch((error) => {

--- a/scripts/mint.ts
+++ b/scripts/mint.ts
@@ -95,6 +95,10 @@ async function main() {
   );
 
   await storeEnv(tokenId, "TOKEN_ID", false);
+
+  /// @dev Awaits for the transaction to be mined.
+  await txErc20.wait();
+  await txErc721.wait();
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Doc Refactor

- Changing the comment description of `make transaction` script on Makefile.
- Adding `wait tx.wait()` to wait transactions to be mined to not mess up the script sequence when saving on `.env` and risking script continuation without the right parameters.