### PR TITLE
feat: Kakarot rpc and ipfs on mockerc721

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,6 +28,7 @@ SEPOLIA_RPC_URL=https://ethereum-sepolia.publicnode.com
 MUMBAI_RPC_URL=https://polygon-mumbai-bor.publicnode.com
 FUJI_RPC_URL=https://avalanche-fuji-c-chain.publicnode.com
 BNB_TESTNET_RPC_URL=https://bsc-testnet.publicnode.com
+KAKAROT_SEPOLIA_RPC_URL=https://sepolia-rpc.kakarot.org
 
 # MAINNETS
 ETH_RPC_URL="https://eth.llamarpc.com"

--- a/contracts/mock/MockERC721.sol
+++ b/contracts/mock/MockERC721.sol
@@ -16,6 +16,6 @@ contract MockERC721 is ERC721 {
   function tokenURI(
     uint256
   ) public view virtual override returns (string memory) {
-    return "ipfs://QmQJnHseE9VPw5qVxuEhxTiZ7avzgkCdFz69rg86UvTZdk/";
+    return "ipfs://QmWodCkovJk18U75g8Veg6rCnw7951vQvTjYfS7J3nMFma/";
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -27,7 +27,7 @@ const config: HardhatUserConfig = {
      * @dev Testnets
      */
     kakarot: {
-      url: `${process.env.KAKAROT_RPC_URL}`,
+      url: `${process.env.KAKAROT_SEPOLIA_RPC_URL}`,
       accounts: [`${DEPLOYER_PRIVATE_KEY}`],
     },
     sepolia: {


### PR DESCRIPTION
- [x] Added kakarot rpc to the `.env` file
- [x] Corrected the name of the kakarot RPC URL in the hardhat file
- [x] Corrected the ipfs link in the `MockERC721` file

closes #221 
closes #220 