### PR TITLE
fix: added missing tables in the docs

### DIFF
--- a/docs/solidity-docgen/interfaces/ISwaplace.md
+++ b/docs/solidity-docgen/interfaces/ISwaplace.md
@@ -44,6 +44,12 @@ Requirements:
 
 Emits a {SwapCreated} event._
 
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Swap | struct ISwap.Swap | is the Swap struct to be created. |
+
 ### acceptSwap
 
 ```solidity
@@ -65,6 +71,13 @@ Emits a {SwapAccepted} event.
 NOTE: The expiry is set to 0, because if the Swap is expired it
 will revert, preventing reentrancy attacks._
 
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| swapId | uint256 | is the ID of the Swap to be accepted. |
+| receiver | address | is the address that will receive the trading assets. |
+
 ### cancelSwap
 
 ```solidity
@@ -83,6 +96,12 @@ Requirements:
 
 Emits a {SwapCanceled} event._
 
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| swapId | uint256 | is the ID of the Swap to be canceled. |
+
 ### getSwap
 
 ```solidity
@@ -94,4 +113,10 @@ _Retrieves the details of a Swap based on the `swapId` provided.
 NOTE: If the Swaps doesn't exist, the values will be defaulted to 0.
 You can check if a Swap exists by checking if the `owner` is the zero address.
 If the `owner` is the zero address, then the Swap doesn't exist._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| swapId | uint256 | is the ID of the Swap to be retrieved. |
 


### PR DESCRIPTION
Added some missing tables text in the `ISwaplace.md` file generated by docgen